### PR TITLE
fix: respect Cobra output writer in list command

### DIFF
--- a/cmd/stackwhere/list.go
+++ b/cmd/stackwhere/list.go
@@ -159,24 +159,31 @@ func (psl *programStackList) runListProgram(cmd *cobra.Command, args []string) e
 			return fmt.Errorf("failed to encode stack usage data to JSON: %w", err)
 		}
 		return nil
-	} else {
-		for _, slots := range usage {
-			fmt.Printf("R10-%d:\n", slots[0].Offset)
-			for _, slot := range slots {
-				size := fmt.Sprintf("%d", slot.ByteSize)
-				if slot.ByteSize == -1 {
-					size = "?"
-				}
+	}
 
-				name := slot.Name
-				if name == "" {
-					name = "(unknown)"
-				}
+	w := cmd.OutOrStdout()
+	for _, slots := range usage {
+		if _, err := fmt.Fprintf(w, "R10-%d:\n", slots[0].Offset); err != nil {
+			return err
+		}
+		for _, slot := range slots {
+			size := fmt.Sprintf("%d", slot.ByteSize)
+			if slot.ByteSize == -1 {
+				size = "?"
+			}
 
-				fmt.Printf("  %s - %s @ %s\n", size, name, slot.FileLineCol)
-				if *psl.flagCallStack {
-					for _, entry := range slot.Callstack {
-						fmt.Printf("    %s @ %s\n", entry.Name, entry.FileLineCol)
+			name := slot.Name
+			if name == "" {
+				name = "(unknown)"
+			}
+
+			if _, err := fmt.Fprintf(w, "  %s - %s @ %s\n", size, name, slot.FileLineCol); err != nil {
+				return err
+			}
+			if *psl.flagCallStack {
+				for _, entry := range slot.Callstack {
+					if _, err := fmt.Fprintf(w, "    %s @ %s\n", entry.Name, entry.FileLineCol); err != nil {
+						return err
 					}
 				}
 			}
@@ -376,9 +383,12 @@ func (psl *programStackList) runListCollection(cmd *cobra.Command, args []string
 			return fmt.Errorf("failed to encode stack usage data to JSON: %w", err)
 		}
 		return nil
-	} else {
-		for _, prog := range keys {
-			fmt.Printf("%3d bytes - %s\n", stackUsagePerProgram[prog], prog)
+	}
+
+	w := cmd.OutOrStdout()
+	for _, prog := range keys {
+		if _, err := fmt.Fprintf(w, "%3d bytes - %s\n", stackUsagePerProgram[prog], prog); err != nil {
+			return err
 		}
 	}
 

--- a/cmd/stackwhere/list_test.go
+++ b/cmd/stackwhere/list_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/cilium/ebpf"
@@ -170,5 +172,42 @@ func TestGetProgramStackUsage(t *testing.T) {
 	expectedStackUsage := int64(56)
 	if stackUsage != expectedStackUsage {
 		t.Errorf("expected stack usage %d, got %d", expectedStackUsage, stackUsage)
+	}
+}
+
+func TestListCollectionWritesToConfiguredOutput(t *testing.T) {
+	cmd := root()
+	cmd.SetArgs([]string{"list", "../../testdata/basic.o"})
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("list command failed: %v", err)
+	}
+
+	got := stdout.String()
+	if !strings.Contains(got, "56 bytes - cil_entry") {
+		t.Fatalf("expected collection output in configured writer, got %q", got)
+	}
+}
+
+func TestListProgramWritesToConfiguredOutput(t *testing.T) {
+	cmd := root()
+	cmd.SetArgs([]string{"list", "../../testdata/basic.o", "cil_entry"})
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("list command failed: %v", err)
+	}
+
+	got := stdout.String()
+	if !strings.Contains(got, "R10-0:") {
+		t.Fatalf("expected program output in configured writer, got %q", got)
+	}
+	if !strings.Contains(got, "32 - a @") {
+		t.Fatalf("expected stack slot details in configured writer, got %q", got)
 	}
 }


### PR DESCRIPTION
Text `list` output goes through `fmt.Printf` today, so `cmd.SetOut(...)` gets ignored.

That bug is real and easy to hit in tests or when wrapping the command. On upstream, `buf` stays empty while `56 bytes - cil_entry` still prints to real stdout. Kinda sneaky.

This switches the text paths to `cmd.OutOrStdout()` and adds regression tests for collection and per-program output.

Repro on `main`:
1. create `cmd := root()`
2. set `cmd.SetArgs([]string{"list", "../../testdata/basic.o"})`
3. set `cmd.SetOut(&buf)`
4. run `cmd.Execute()`
5. `buf.String()` is still empty

Checks:
`go test ./...`
