### PR TITLE
fix: include inferred stack usage in collection summaries

### DIFF
--- a/cmd/stackwhere/list_test.go
+++ b/cmd/stackwhere/list_test.go
@@ -94,6 +94,22 @@ func TestCollectionSummaryIncludesProgramUsage(t *testing.T) {
 	}
 }
 
+func TestListCollectionIncludesInstructionOnlyStackUsage(t *testing.T) {
+	cmd := root()
+	cmd.SetArgs([]string{"list", "../../testdata/noinline.o"})
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("list command failed: %v", err)
+	}
+
+	if got := stdout.String(); !strings.Contains(got, "8 bytes - entry") {
+		t.Fatalf("expected instruction-derived stack usage in collection output, got %q", got)
+	}
+}
+
 func TestListCollectionWritesToConfiguredOutput(t *testing.T) {
 	cmd := root()
 	cmd.SetArgs([]string{"list", "../../testdata/basic.o"})

--- a/cmd/stackwhere/web.go
+++ b/cmd/stackwhere/web.go
@@ -158,7 +158,10 @@ func newWebApp(collectionPath string, sourceDirs []string) (*webApp, error) {
 		return nil, err
 	}
 
-	summary := analyzer.CollectionSummary()
+	summary, err := analyzer.CollectionSummaryInCollection()
+	if err != nil {
+		return nil, err
+	}
 	spec, functions, err := loadCollectionFunctions(collectionPath)
 	if err != nil {
 		return nil, err

--- a/cmd/stackwhere/web_test.go
+++ b/cmd/stackwhere/web_test.go
@@ -78,6 +78,24 @@ func TestWebHandlerServesLandingPage(t *testing.T) {
 	}
 }
 
+func TestWebHandlerIncludesInstructionOnlyStackUsage(t *testing.T) {
+	app, err := newWebApp("../../testdata/noinline.o", nil)
+	if err != nil {
+		t.Fatalf("failed to initialize web app: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	app.handler().ServeHTTP(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("unexpected status code: got %d want 200", rr.Code)
+	}
+	if body := rr.Body.String(); !strings.Contains(body, "8 bytes") {
+		t.Fatalf("expected instruction-derived stack usage in landing page, got %q", body)
+	}
+}
+
 func TestWebHandlerServesProgramPage(t *testing.T) {
 	app, err := newWebApp("../../testdata/basic.o", nil)
 	if err != nil {

--- a/internal/stackview/stackview.go
+++ b/internal/stackview/stackview.go
@@ -113,13 +113,40 @@ func (a *Analyzer) CollectionSummaryInCollection() ([]ProgramStackUsage, error) 
 
 	summary := a.CollectionSummary()
 	filtered := make([]ProgramStackUsage, 0, len(summary))
+	subProgsDwarf := a.tree.ByType(dbgdwarf.TagSubprogram)
 	for _, prog := range summary {
-		if fn, ok := a.functions[prog.Name]; ok && fn.fn != nil {
-			filtered = append(filtered, prog)
+		fn, ok := a.functions[prog.Name]
+		if !ok || fn.fn == nil {
+			continue
 		}
+
+		subProgDwarfIdx := slices.IndexFunc(subProgsDwarf, func(n *dbgdwarf.Node) bool {
+			return n.Name() == prog.Name
+		})
+		if subProgDwarfIdx != -1 {
+			inferredUsage := stackUsageFromSlots(stackSlotsFromInsns(fn, subProgsDwarf[subProgDwarfIdx]))
+			prog.StackUsage = max(prog.StackUsage, inferredUsage)
+		}
+
+		filtered = append(filtered, prog)
 	}
 
 	return filtered, nil
+}
+
+func stackUsageFromSlots(slots slotList) int64 {
+	var largestOffset int64
+	for _, group := range slots {
+		for _, slot := range group {
+			largestOffset = max(largestOffset, slot.Offset)
+		}
+	}
+
+	if largestOffset%8 != 0 {
+		largestOffset = ((largestOffset / 8) + 1) * 8
+	}
+
+	return largestOffset
 }
 
 // ProgramDetails returns grouped stack slot usage for a single program.


### PR DESCRIPTION
`list` and web could show `0 bytes` when DWARF omits a stack location

reuse existing instruction-derived slots for collection summaries

Repro: `stackwhere list testdata/noinline.o` used to print `0 bytes - entry`; now prints `8 bytes - entry`