### PR TITLE
fix: bind web server to loopback by default

### DIFF
--- a/cmd/stackwhere/web.go
+++ b/cmd/stackwhere/web.go
@@ -43,7 +43,7 @@ func webCommand() *cobra.Command {
 
 	flags := c.Flags()
 	wc := &webCmd{
-		flagAddr: flags.String("addr", ":8080", "Address to bind the local web server to"),
+		flagAddr: flags.String("addr", "127.0.0.1:8080", "Address to bind the local web server to"),
 		flagSourceDirs: flags.StringSlice(
 			"source-dir",
 			nil,

--- a/cmd/stackwhere/web_test.go
+++ b/cmd/stackwhere/web_test.go
@@ -46,6 +46,18 @@ func TestStartupURL(t *testing.T) {
 	}
 }
 
+func TestWebCommandBindsLoopbackByDefault(t *testing.T) {
+	cmd := webCommand()
+	addr, err := cmd.Flags().GetString("addr")
+	if err != nil {
+		t.Fatalf("failed to get addr flag: %v", err)
+	}
+
+	if want := "127.0.0.1:8080"; addr != want {
+		t.Fatalf("default addr = %q, want %q", addr, want)
+	}
+}
+
 func TestWebCommandRequiresCollectionArg(t *testing.T) {
 	cmd := root()
 	cmd.SetArgs([]string{"web"})


### PR DESCRIPTION
The local web UI bound to every interface by default

It now binds to `127.0.0.1:8080` by default. LAN access still works when explicitly configured

Repro:
`stackwhere web object.o`

It prints a loopback URL, but the old default listened on every interface