### PR TITLE
fix: restore absolute DWARF source paths

### DIFF
--- a/internal/dwarf/tree.go
+++ b/internal/dwarf/tree.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
+	"slices"
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
@@ -70,7 +72,7 @@ func newDWARFTreeReader(fileReader io.ReaderAt) (*Tree, error) {
 				return nil, fmt.Errorf("failed to create line reader: %w", err)
 			}
 
-			n = newNode(tree, entry, lr.Files())
+			n = newNode(tree, entry, normalizeCompileUnitFiles(entry, lr.Files()))
 			tree.root = n
 			cur = n
 		} else {
@@ -87,6 +89,31 @@ func newDWARFTreeReader(fileReader io.ReaderAt) (*Tree, error) {
 	}
 
 	return tree, nil
+}
+
+func normalizeCompileUnitFiles(entry *dwarf.Entry, files []*dwarf.LineFile) []*dwarf.LineFile {
+	name, _ := entry.Val(dwarf.AttrName).(string)
+	compDir, _ := entry.Val(dwarf.AttrCompDir).(string)
+	if !path.IsAbs(name) || compDir == "" {
+		return files
+	}
+
+	// debug/dwarf joins DWARF 5 directory and file entries even when the file
+	// name is absolute. Restore the compilation unit path when that happened.
+	joinedName := path.Join(compDir, name)
+	for i, file := range files {
+		if file == nil || file.Name != joinedName {
+			continue
+		}
+
+		normalized := slices.Clone(files)
+		normalizedFile := *file
+		normalizedFile.Name = name
+		normalized[i] = &normalizedFile
+		return normalized
+	}
+
+	return files
 }
 
 type Tree struct {

--- a/internal/dwarf/tree_test.go
+++ b/internal/dwarf/tree_test.go
@@ -5,8 +5,67 @@ package dwarf
 
 import (
 	"debug/dwarf"
+	"slices"
 	"testing"
 )
+
+func TestNormalizeCompileUnitFiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		unitName string
+		compDir  string
+		fileName string
+		want     string
+	}{
+		{
+			name:     "joined absolute path",
+			unitName: "/src/basic.c",
+			compDir:  "/go",
+			fileName: "/go/src/basic.c",
+			want:     "/src/basic.c",
+		},
+		{
+			name:     "relative unit path",
+			unitName: "src/basic.c",
+			compDir:  "/go",
+			fileName: "/go/src/basic.c",
+			want:     "/go/src/basic.c",
+		},
+		{
+			name:     "correct absolute path",
+			unitName: "/src/basic.c",
+			compDir:  "/go",
+			fileName: "/src/basic.c",
+			want:     "/src/basic.c",
+		},
+		{
+			name:     "unrelated file",
+			unitName: "/src/basic.c",
+			compDir:  "/go",
+			fileName: "/go/src/header.h",
+			want:     "/go/src/header.h",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := &dwarf.Entry{Field: []dwarf.Field{
+				{Attr: dwarf.AttrName, Val: tt.unitName},
+				{Attr: dwarf.AttrCompDir, Val: tt.compDir},
+			}}
+			file := &dwarf.LineFile{Name: tt.fileName}
+			files := []*dwarf.LineFile{file}
+
+			got := normalizeCompileUnitFiles(entry, files)
+			if got[0].Name != tt.want {
+				t.Fatalf("normalized file name = %q, want %q", got[0].Name, tt.want)
+			}
+			if file.Name != tt.fileName || !slices.Equal(files, []*dwarf.LineFile{file}) {
+				t.Fatalf("normalizeCompileUnitFiles mutated its input")
+			}
+		})
+	}
+}
 
 func TestNodeLocationsUseCompilationUnitFiles(t *testing.T) {
 	firstUnitFiles := []*dwarf.LineFile{{Name: "first.c"}}


### PR DESCRIPTION
Clang 22 can emit an absolute DWARF file name alongside a compilation directory
Go's DWARF reader joins them, so stackwhere reports `/go/src/basic.c` even though the real path is `/src/basic.c`

Repro:

```sh
audit_dir=$(mktemp -d)
docker run -v "$PWD/testdata:/src:ro" -v "$audit_dir:/out" -w /go ghcr.io/cilium/ebpf-builder:1777990914 clang-22 -g -O2 -target bpf -c /src/basic.c -o /out/basic.o
go run ./cmd/stackwhere list "$audit_dir/basic.o" cil_entry
```

Before: `32 - a @ /go/src/basic.c:72`

After: `32 - a @ /src/basic.c:72`

The fix restores the compilation unit path only when the bad joined form matches exactly
Relative and already-correct paths stay as-is, regression coverage is included too

Tests: `go test ./...`, `go test -race ./...`, `go vet ./...`, `golangci-lint run`
