### PR TITLE
fix: announce web UI after binding succeeds

### DIFF
--- a/cmd/stackwhere/web.go
+++ b/cmd/stackwhere/web.go
@@ -63,6 +63,14 @@ func (wc *webCmd) runE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	listener, err := net.Listen("tcp", *wc.flagAddr)
+	if err != nil {
+		return fmt.Errorf("web server failed: %w", err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+
 	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Serving stackwhere web UI on %s\n", startupURL(*wc.flagAddr)); err != nil {
 		return err
 	}
@@ -72,7 +80,7 @@ func (wc *webCmd) runE(cmd *cobra.Command, args []string) error {
 		Handler: app.handler(),
 	}
 
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("web server failed: %w", err)
 	}
 	return nil

--- a/cmd/stackwhere/web_test.go
+++ b/cmd/stackwhere/web_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"net"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -52,6 +53,29 @@ func TestWebCommandRequiresCollectionArg(t *testing.T) {
 
 	if err := cmd.Execute(); err == nil {
 		t.Fatalf("expected web command to fail when collection argument is missing")
+	}
+}
+
+func TestWebCommandDoesNotAnnounceFailedBind(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve test address: %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	cmd := root()
+	cmd.SetArgs([]string{"web", "../../testdata/basic.o", "--addr", listener.Addr().String()})
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected web command to fail when address is already in use")
+	}
+	if got := stdout.String(); strings.Contains(got, "Serving stackwhere web UI") {
+		t.Fatalf("web command announced a server that failed to start: %q", got)
 	}
 }
 


### PR DESCRIPTION
Starting `stackwhere web` on an occupied port printed the serving URL before failing to bind

Repro:
```sh
python3 -m http.server 8080
stackwhere web object.o
```

This binds first and only prints the URL after the listener is ready. 
A regression test uses a real occupied TCP socket, successful starts work the same