### PR TITLE
fix: prefer relocated source path suffixes

### DIFF
--- a/cmd/stackwhere/web.go
+++ b/cmd/stackwhere/web.go
@@ -569,6 +569,17 @@ func (wa *webApp) resolveSourcePath(requestedPath string) (string, bool) {
 	candidates := make([]string, 0, len(wa.sourceDirs))
 	if filepath.IsAbs(cleanPath) {
 		candidates = append(candidates, cleanPath)
+
+		pathWithoutVolume := strings.TrimPrefix(cleanPath, filepath.VolumeName(cleanPath))
+		parts := strings.FieldsFunc(pathWithoutVolume, func(r rune) bool {
+			return r == rune(filepath.Separator)
+		})
+		for i := range parts {
+			suffix := filepath.Join(parts[i:]...)
+			for _, sourceDir := range wa.sourceDirs {
+				candidates = append(candidates, filepath.Join(sourceDir, suffix))
+			}
+		}
 	} else {
 		for _, sourceDir := range wa.sourceDirs {
 			candidates = append(candidates, filepath.Join(sourceDir, cleanPath))

--- a/cmd/stackwhere/web_test.go
+++ b/cmd/stackwhere/web_test.go
@@ -187,6 +187,43 @@ func TestWebHandlerServesSourcePage(t *testing.T) {
 	}
 }
 
+func TestWebHandlerPrefersRelocatedSourcePath(t *testing.T) {
+	sourceDir := t.TempDir()
+	for _, dir := range []string{"a", "src"} {
+		if err := os.Mkdir(filepath.Join(sourceDir, dir), 0o755); err != nil {
+			t.Fatalf("failed to create source directory: %v", err)
+		}
+	}
+
+	if err := os.WriteFile(filepath.Join(sourceDir, "a", "basic.c"), []byte("int wrong_source;\n"), 0o644); err != nil {
+		t.Fatalf("failed to write wrong source file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "src", "basic.c"), []byte("int expected_source;\n"), 0o644); err != nil {
+		t.Fatalf("failed to write expected source file: %v", err)
+	}
+
+	app, err := newWebApp("../../testdata/basic.o", []string{sourceDir})
+	if err != nil {
+		t.Fatalf("failed to initialize web app: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/source?file=%2Fsrc%2Fbasic.c", nil)
+	rr := httptest.NewRecorder()
+	app.handler().ServeHTTP(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("unexpected status code: got %d want 200", rr.Code)
+	}
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "expected_source") {
+		t.Fatalf("expected relocated source file, got %q", body)
+	}
+	if strings.Contains(body, "wrong_source") {
+		t.Fatalf("unexpected basename-only source match, got %q", body)
+	}
+}
+
 func TestWebHandlerSourcePageNotFound(t *testing.T) {
 	app, err := newWebApp("../../testdata/basic.o", nil)
 	if err != nil {


### PR DESCRIPTION
Absolute DWARF paths can fall back to the first matching basename in `web`. 
With both `a/basic.c` and `src/basic.c`, a `/src/basic.c` link shows `a/basic.c`

The resolver now tries relocated path suffixes first, then keeps the basename fallback

Repro:
1. Put different files at `a/basic.c` and `src/basic.c`
2. Run `stackwhere web collection.o --source-dir .`
3. Open `/source?file=%2Fsrc%2Fbasic.c`

Before it picks `a/basic.c`, now it picks `src/basic.c`

Tests: `go test ./...`, `go test -race ./...`, `go vet ./...`, `golangci-lint run`