### PR TITLE
fix: include void functions in collection summaries

### DIFF
--- a/cmd/stackwhere/list_test.go
+++ b/cmd/stackwhere/list_test.go
@@ -110,6 +110,22 @@ func TestListCollectionIncludesInstructionOnlyStackUsage(t *testing.T) {
 	}
 }
 
+func TestListCollectionIncludesVoidFunction(t *testing.T) {
+	cmd := root()
+	cmd.SetArgs([]string{"list", "../../testdata/noinline.o"})
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("list command failed: %v", err)
+	}
+
+	if got := stdout.String(); !strings.Contains(got, "0 bytes - helper") {
+		t.Fatalf("expected void helper in collection output, got %q", got)
+	}
+}
+
 func TestListCollectionWritesToConfiguredOutput(t *testing.T) {
 	cmd := root()
 	cmd.SetArgs([]string{"list", "../../testdata/basic.o"})

--- a/internal/stackview/stackview.go
+++ b/internal/stackview/stackview.go
@@ -324,7 +324,9 @@ func isBPFProgram(n *dbgdwarf.Node) bool {
 		return false
 	}
 
-	if n.Entry().Val(dbgdwarf.AttrType) == nil {
+	// Concrete functions have an address or ranges. Unlike declarations, void
+	// functions have executable code but no return type attribute.
+	if n.Entry().Val(dbgdwarf.AttrLowpc) == nil && n.Entry().Val(dbgdwarf.AttrRanges) == nil {
 		return false
 	}
 


### PR DESCRIPTION
Collection summaries skip concrete `void` BPF-to-BPF functions because they have no `DW_AT_type`. 
This is a real gotcha since `void` helpers are normal BPF code, and direct lookup already works

The fix checks for code addresses or ranges instead. Declaration-only entries stay filtered

Repro:
```console
$ go run ./cmd/stackwhere list testdata/noinline.o
  8 bytes - entry
```

Before, `helper` is missing. After the fix:
```console
  8 bytes - entry
  0 bytes - helper
```

Tests: `go test -v ./...`, `go test -race ./...`, `go vet ./...`, `golangci-lint run ./...`