### PR TITLE
fix: announce assigned web server port

### DIFF
--- a/cmd/stackwhere/web.go
+++ b/cmd/stackwhere/web.go
@@ -71,7 +71,7 @@ func (wc *webCmd) runE(cmd *cobra.Command, args []string) error {
 		_ = listener.Close()
 	}()
 
-	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Serving stackwhere web UI on %s\n", startupURL(*wc.flagAddr)); err != nil {
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Serving stackwhere web UI on %s\n", startupURL(*wc.flagAddr, listener.Addr().String())); err != nil {
 		return err
 	}
 
@@ -86,10 +86,13 @@ func (wc *webCmd) runE(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func startupURL(addr string) string {
+func startupURL(addr, boundAddr string) string {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return "http://" + addr
+	}
+	if _, boundPort, err := net.SplitHostPort(boundAddr); err == nil {
+		port = boundPort
 	}
 
 	if host == "" {

--- a/cmd/stackwhere/web_test.go
+++ b/cmd/stackwhere/web_test.go
@@ -12,36 +12,47 @@ import (
 
 func TestStartupURL(t *testing.T) {
 	tests := []struct {
-		name string
-		addr string
-		want string
+		name      string
+		addr      string
+		boundAddr string
+		want      string
 	}{
 		{
-			name: "host omitted",
-			addr: ":8080",
-			want: "http://127.0.0.1:8080",
+			name:      "host omitted",
+			addr:      ":8080",
+			boundAddr: "[::]:8080",
+			want:      "http://127.0.0.1:8080",
 		},
 		{
-			name: "explicit ipv4 host",
-			addr: "0.0.0.0:8080",
-			want: "http://0.0.0.0:8080",
+			name:      "explicit ipv4 host",
+			addr:      "0.0.0.0:8080",
+			boundAddr: "0.0.0.0:8080",
+			want:      "http://0.0.0.0:8080",
 		},
 		{
-			name: "explicit hostname",
-			addr: "localhost:9090",
-			want: "http://localhost:9090",
+			name:      "explicit hostname",
+			addr:      "localhost:9090",
+			boundAddr: "127.0.0.1:9090",
+			want:      "http://localhost:9090",
 		},
 		{
-			name: "explicit ipv6 host",
-			addr: "[::1]:8080",
-			want: "http://[::1]:8080",
+			name:      "explicit ipv6 host",
+			addr:      "[::1]:8080",
+			boundAddr: "[::1]:8080",
+			want:      "http://[::1]:8080",
+		},
+		{
+			name:      "ephemeral port",
+			addr:      "127.0.0.1:0",
+			boundAddr: "127.0.0.1:36833",
+			want:      "http://127.0.0.1:36833",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := startupURL(tt.addr); got != tt.want {
-				t.Fatalf("startupURL(%q) = %q, want %q", tt.addr, got, tt.want)
+			if got := startupURL(tt.addr, tt.boundAddr); got != tt.want {
+				t.Fatalf("startupURL(%q, %q) = %q, want %q", tt.addr, tt.boundAddr, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
`stackwhere web` prints port 0 when the OS picked a real one

Repro:
```bash
stackwhere web object.o --addr 127.0.0.1:0
Serving stackwhere web UI on http://127.0.0.1:0
```

This uses the assigned listener port while keeping the configured host. 
Existing URLs stay the same

Tests: `go test ./...`, `go test -race ./...`, `go vet ./...`, `golangci-lint run ./...`

Follow-up to #19