### PR TITLE
fix: report no stack usage for zero-slot programs

### DIFF
--- a/cmd/stackwhere/list.go
+++ b/cmd/stackwhere/list.go
@@ -64,6 +64,11 @@ func (psl *programStackList) runListProgram(cmd *cobra.Command, args []string) e
 	}
 
 	w := cmd.OutOrStdout()
+	if len(usage) == 0 {
+		_, err := fmt.Fprintln(w, "No stack usage.")
+		return err
+	}
+
 	for _, slots := range usage {
 		if !*psl.flagCallStack {
 			slots = slices.CompactFunc(slices.Clone(slots), func(a, b stackview.SlotUsage) bool {

--- a/cmd/stackwhere/list_test.go
+++ b/cmd/stackwhere/list_test.go
@@ -195,6 +195,22 @@ func TestListProgramWritesToConfiguredOutput(t *testing.T) {
 	}
 }
 
+func TestListProgramReportsNoStackUsage(t *testing.T) {
+	cmd := root()
+	cmd.SetArgs([]string{"list", "../../testdata/noinline.o", "helper"})
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("list command failed: %v", err)
+	}
+
+	if got, want := stdout.String(), "No stack usage.\n"; got != want {
+		t.Fatalf("expected explicit no-stack-usage output, got %q, want %q", got, want)
+	}
+}
+
 func TestListProgramCallStackPreservesDistinctInlineCallSites(t *testing.T) {
 	cmd := root()
 	cmd.SetArgs([]string{"list", "../../testdata/basic.o", "cil_entry", "--call-stack"})


### PR DESCRIPTION
`list <collection> <program>` prints literally nothing when a program has zero stack slots. 
no error, no message, just empty stdout, exit 0

this got way more reachable after #21, since void/simple helpers now show up in the collection summary as "0 bytes", so the natural next step is drilling into them with `list <collection> <program>`, and you just get silence back

repro:
```bash
stackwhere list testdata/noinline.o helper

```

fix prints `No stack usage` in text mode when there are no slots. json mode already returned `[]` for this case so thats left untouched.

added a test for it, go test + golangci-lint both pass
