### PR TITLE
Optionally load debug info from separate file(s)

### DIFF
--- a/cmd/stackwhere/list.go
+++ b/cmd/stackwhere/list.go
@@ -44,7 +44,7 @@ func (psl *programStackList) runListProgram(cmd *cobra.Command, args []string) e
 	collectionPath := args[0]
 	functionName := args[1]
 
-	analyzer, err := stackview.NewAnalyzer(collectionPath)
+	analyzer, err := stackview.NewAnalyzer(collectionPath, dwarves(cmd))
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func (psl *programStackList) runListProgram(cmd *cobra.Command, args []string) e
 func (psl *programStackList) runListCollection(cmd *cobra.Command, args []string) error {
 	collectionPath := args[0]
 
-	analyzer, err := stackview.NewAnalyzer(collectionPath)
+	analyzer, err := stackview.NewAnalyzer(collectionPath, dwarves(cmd))
 	if err != nil {
 		return err
 	}

--- a/cmd/stackwhere/list_test.go
+++ b/cmd/stackwhere/list_test.go
@@ -23,7 +23,7 @@ func hasSlot(slots [][]stackview.SlotUsage, wantName string, wantSize int64) boo
 }
 
 func TestProgramDetailsFromDWARF(t *testing.T) {
-	analyzer, err := stackview.NewAnalyzer("../../testdata/basic.o")
+	analyzer, err := stackview.NewAnalyzer("../../testdata/basic.o", nil)
 	if err != nil {
 		t.Fatalf("failed to initialize analyzer: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestProgramDetailsFromDWARF(t *testing.T) {
 }
 
 func TestProgramDetailsFromInsns(t *testing.T) {
-	analyzer, err := stackview.NewAnalyzer("../../testdata/spill.o")
+	analyzer, err := stackview.NewAnalyzer("../../testdata/spill.o", nil)
 	if err != nil {
 		t.Fatalf("failed to initialize analyzer: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestProgramDetailsFromInsns(t *testing.T) {
 }
 
 func TestCollectionSummaryIncludesProgramUsage(t *testing.T) {
-	analyzer, err := stackview.NewAnalyzer("../../testdata/basic.o")
+	analyzer, err := stackview.NewAnalyzer("../../testdata/basic.o", nil)
 	if err != nil {
 		t.Fatalf("failed to initialize analyzer: %v", err)
 	}

--- a/cmd/stackwhere/main.go
+++ b/cmd/stackwhere/main.go
@@ -12,7 +12,10 @@ func main() {
 	}
 }
 
-const jsonFlagName = "json"
+const (
+	jsonFlagName    = "json"
+	dwarvesFlagName = "dwarf"
+)
 
 func jsonOutput(cmd *cobra.Command) bool {
 	jsonFlag, err := cmd.Flags().GetBool(jsonFlagName)
@@ -22,6 +25,11 @@ func jsonOutput(cmd *cobra.Command) bool {
 	return jsonFlag
 }
 
+func dwarves(cmd *cobra.Command) []string {
+	dwarves, _ := cmd.Flags().GetStringArray(dwarvesFlagName)
+	return dwarves
+}
+
 func root() *cobra.Command {
 	c := &cobra.Command{
 		Use: "stackwhere",
@@ -29,6 +37,7 @@ func root() *cobra.Command {
 
 	pFlags := c.PersistentFlags()
 	pFlags.BoolP(jsonFlagName, "j", false, "Output in JSON format")
+	pFlags.StringArrayP(dwarvesFlagName, "D", nil, "Explicit DWARF files(s)")
 
 	const primaryGroupID = "primary"
 	c.AddGroup(

--- a/cmd/stackwhere/web.go
+++ b/cmd/stackwhere/web.go
@@ -58,7 +58,7 @@ func webCommand() *cobra.Command {
 func (wc *webCmd) runE(cmd *cobra.Command, args []string) error {
 	collectionPath := args[0]
 
-	app, err := newWebApp(collectionPath, *wc.flagSourceDirs)
+	app, err := newWebApp(collectionPath, *wc.flagSourceDirs, dwarves(cmd))
 	if err != nil {
 		return err
 	}
@@ -158,8 +158,8 @@ const (
 
 var errSourceFileFound = errors.New("source file found")
 
-func newWebApp(collectionPath string, sourceDirs []string) (*webApp, error) {
-	analyzer, err := stackview.NewAnalyzer(collectionPath)
+func newWebApp(collectionPath string, sourceDirs []string, dwarves []string) (*webApp, error) {
+	analyzer, err := stackview.NewAnalyzer(collectionPath, dwarves)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/stackwhere/web_test.go
+++ b/cmd/stackwhere/web_test.go
@@ -91,7 +91,7 @@ func TestWebCommandDoesNotAnnounceFailedBind(t *testing.T) {
 }
 
 func TestWebHandlerServesLandingPage(t *testing.T) {
-	app, err := newWebApp("../../testdata/basic.o", nil)
+	app, err := newWebApp("../../testdata/basic.o", nil, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize web app: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestWebHandlerServesLandingPage(t *testing.T) {
 }
 
 func TestWebHandlerIncludesInstructionOnlyStackUsage(t *testing.T) {
-	app, err := newWebApp("../../testdata/noinline.o", nil)
+	app, err := newWebApp("../../testdata/noinline.o", nil, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize web app: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestWebHandlerIncludesInstructionOnlyStackUsage(t *testing.T) {
 }
 
 func TestWebHandlerServesProgramPage(t *testing.T) {
-	app, err := newWebApp("../../testdata/basic.o", nil)
+	app, err := newWebApp("../../testdata/basic.o", nil, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize web app: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestWebHandlerServesProgramPage(t *testing.T) {
 }
 
 func TestWebHandlerServesSourcePage(t *testing.T) {
-	app, err := newWebApp("../../testdata/basic.o", nil)
+	app, err := newWebApp("../../testdata/basic.o", nil, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize web app: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestWebHandlerPrefersRelocatedSourcePath(t *testing.T) {
 		t.Fatalf("failed to write expected source file: %v", err)
 	}
 
-	app, err := newWebApp("../../testdata/basic.o", []string{sourceDir})
+	app, err := newWebApp("../../testdata/basic.o", []string{sourceDir}, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize web app: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestWebHandlerPrefersRelocatedSourcePath(t *testing.T) {
 }
 
 func TestWebHandlerSourcePageNotFound(t *testing.T) {
-	app, err := newWebApp("../../testdata/basic.o", nil)
+	app, err := newWebApp("../../testdata/basic.o", nil, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize web app: %v", err)
 	}
@@ -256,7 +256,7 @@ func TestWebHandlerSourcePageNotFound(t *testing.T) {
 }
 
 func TestWebHandlerServesEmbeddedStaticAsset(t *testing.T) {
-	app, err := newWebApp("../../testdata/basic.o", nil)
+	app, err := newWebApp("../../testdata/basic.o", nil, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize web app: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestWebHandlerServesEmbeddedStaticAsset(t *testing.T) {
 }
 
 func TestWebHandlerRejectsUnsupportedSourceType(t *testing.T) {
-	app, err := newWebApp("../../testdata/basic.o", nil)
+	app, err := newWebApp("../../testdata/basic.o", nil, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize web app: %v", err)
 	}
@@ -301,7 +301,7 @@ func TestWebHandlerRejectsSourceTraversal(t *testing.T) {
 		t.Fatalf("failed to create source file outside allowlist: %v", err)
 	}
 
-	app, err := newWebApp("../../testdata/basic.o", []string{allowedDir})
+	app, err := newWebApp("../../testdata/basic.o", []string{allowedDir}, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize web app: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestWebHandlerRejectsAbsolutePathOutsideSourceDir(t *testing.T) {
 		t.Fatalf("failed to create source file outside allowlist: %v", err)
 	}
 
-	app, err := newWebApp("../../testdata/basic.o", []string{allowedDir})
+	app, err := newWebApp("../../testdata/basic.o", []string{allowedDir}, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize web app: %v", err)
 	}

--- a/internal/stackview/stackview.go
+++ b/internal/stackview/stackview.go
@@ -24,7 +24,7 @@ var ErrFunctionNotFoundInCollection = errors.New("function not found in eBPF col
 // Analyzer provides stack usage information for one collection file.
 type Analyzer struct {
 	collectionPath string
-	tree           *dbgdwarf.Tree
+	trees          []*dbgdwarf.Tree
 	functions      map[string]bpfFn
 }
 
@@ -78,22 +78,30 @@ func (s slotList) Add(slot SlotUsage) slotList {
 }
 
 // NewAnalyzer parses DWARF data from a collection path.
-func NewAnalyzer(collectionPath string) (*Analyzer, error) {
-	tree, err := dbgdwarf.NewDWARFTree(collectionPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse DWARF data: %w", err)
+func NewAnalyzer(collectionPath string, dwarfPathes []string) (*Analyzer, error) {
+	if len(dwarfPathes) == 0 {
+		dwarfPathes = []string{collectionPath}
+	}
+
+	var trees []*dbgdwarf.Tree
+	for _, dwarfPath := range dwarfPathes {
+		tree, err := dbgdwarf.NewDWARFTree(dwarfPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse DWARF data: %w", err)
+		}
+		trees = append(trees, tree)
 	}
 
 	return &Analyzer{
 		collectionPath: collectionPath,
-		tree:           tree,
+		trees:          trees,
 	}, nil
 }
 
 // CollectionSummary returns peak stack usage for all BPF programs in the collection.
 func (a *Analyzer) CollectionSummary() []ProgramStackUsage {
 	stackUsagePerProgram := map[string]int64{}
-	for _, prog := range a.tree.ByType(dbgdwarf.TagSubprogram) {
+	for _, prog := range a.subProgsDwarf() {
 		if !isBPFProgram(prog) {
 			continue
 		}
@@ -113,7 +121,7 @@ func (a *Analyzer) CollectionSummaryInCollection() ([]ProgramStackUsage, error) 
 
 	summary := a.CollectionSummary()
 	stackUsagePerProgram := make(map[string]int64, len(summary))
-	subProgsDwarf := a.tree.ByType(dbgdwarf.TagSubprogram)
+	subProgsDwarf := a.subProgsDwarf()
 	for _, prog := range summary {
 		fn, ok := a.functions[prog.Name]
 		if !ok || fn.fn == nil {
@@ -121,7 +129,10 @@ func (a *Analyzer) CollectionSummaryInCollection() ([]ProgramStackUsage, error) 
 		}
 
 		subProgDwarfIdx := slices.IndexFunc(subProgsDwarf, func(n *dbgdwarf.Node) bool {
-			return n.Name() == prog.Name
+			// We might have multiple debug infos for a single symbol
+			// due to multiple DWARF files considered. Prefer
+			// definitions to forward declarations.
+			return isBPFProgram(n) && n.Name() == prog.Name
 		})
 		if subProgDwarfIdx != -1 {
 			inferredUsage := stackUsageFromSlots(stackSlotsFromInsns(fn, subProgsDwarf[subProgDwarfIdx]))
@@ -155,7 +166,7 @@ func (a *Analyzer) ProgramDetails(functionName string) ([][]SlotUsage, error) {
 		return nil, err
 	}
 
-	subProgsDwarf := a.tree.ByType(dbgdwarf.TagSubprogram)
+	subProgsDwarf := a.subProgsDwarf()
 	subProgDwarfIdx := slices.IndexFunc(subProgsDwarf, func(n *dbgdwarf.Node) bool {
 		return n.Name() == functionName
 	})
@@ -174,6 +185,13 @@ func (a *Analyzer) ProgramDetails(functionName string) ([][]SlotUsage, error) {
 	usage = normalizeSlotUsage(usage)
 
 	return usage, nil
+}
+
+func (a *Analyzer) subProgsDwarf() (res []*dbgdwarf.Node) {
+	for _, tree := range a.trees {
+		res = append(res, tree.ByType(dbgdwarf.TagSubprogram)...)
+	}
+	return
 }
 
 func (a *Analyzer) loadFunctions() error {


### PR DESCRIPTION
stackwhere relies on DWARF debug info embedded in eBPF object file. Add -D option to point the tool to a separate object file with debug info. The option can be specified multiple times to pass a list of files.

This feature is intended for `bpftool gen object` workflows. Bpftool links multiple eBPF object files together. The final merged object file lacks debug info. With -D option, stackwhere can use debug info from source object files.